### PR TITLE
recipes: use '=' instead of '==' for test commands

### DIFF
--- a/classes/image_types_marvell.bbclass
+++ b/classes/image_types_marvell.bbclass
@@ -28,7 +28,7 @@ IMAGE_CMD_sdcard () {
 	dd if=${SDCARD_ROOTFS} of=${SDCARD} conv=notrunc seek=1 bs=${IMAGE_ROOTFS_ALIGNMENT}M && sync && sync
 
 	# write u-boot image
-	if [ "${UBOOT_SUFFIX}" == "mmc" ]
+	if [ "${UBOOT_SUFFIX}" = "mmc" ]
 	then
 		dd if="${DEPLOY_DIR_IMAGE}/u-boot.${UBOOT_SUFFIX}" of=${SDCARD} conv=notrunc seek=1 bs=512 && sync && sync
 	fi

--- a/recipes-bsp/u-boot/u-boot-armada38x.bb
+++ b/recipes-bsp/u-boot/u-boot-armada38x.bb
@@ -41,7 +41,7 @@ do_compile () {
 
 	export CROSS_COMPILE=${TARGET_PREFIX}
 
-	if [ "${UBOOT_MARVELL_MACHINE}" == "armada_38x_clearfog" ]
+	if [ "${UBOOT_MARVELL_MACHINE}" = "armada_38x_clearfog" ]
 	then
 		make ${UBOOT_MARVELL_MACHINE}_config
 		make u-boot.mmc


### PR DESCRIPTION
'==' isn't POSIX compliant.